### PR TITLE
Convert ComputeAorta/ci-github to GitHub Actions

### DIFF
--- a/.github/workflows/.gitlab-ci-nightly_pipeline.yml
+++ b/.github/workflows/.gitlab-ci-nightly_pipeline.yml
@@ -1,0 +1,1034 @@
+# Environment variables defined in a calling workflow are not accessible to this reusable workflow. Refer to the documentation for further details on this limitation.
+name: .gitlab-ci-nightly_pipeline
+on:
+  workflow_call:
+jobs:
+  env-info:
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run: 'echo "Building: $NIGHTLY_LLVM_PREVIOUS / $NIGHTLY_LLVM_LATEST"'
+    - run: env
+  ca_trigger_llvm:
+    needs: env-info
+    runs-on: ubuntu-latest
+    if: $NIGHTLY_RUN_BUILD_LLVM == "1"
+    timeout-minutes: 3600
+    env:
+      LLVM_BRANCH: "$NIGHTLY_BUILD_LLVM_BRANCHNAME"
+      SHAREDSTORAGE_NAME: "$NIGHTLY_LLVM_LATEST"
+      DRY_RUN: 'FALSE'
+      PUSH_TAG: 'TRUE'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Run downstream workflow
+      run: gh workflow run $WORKFLOW_FILE --repo ComputeAorta/ca-llvm
+      env:
+        WORKFLOW_FILE: UPDATE_ME
+        GH_TOKEN: "${{ github.token }}"
+  ca_meta_requires_llvm:
+    needs: env-info
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_BUILD_LLVM == "1" || "1" == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run: echo "LLVM is go"
+  build-native:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH:
+        - x86
+        - x86_64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-windows:
+    needs: ca_meta_requires_llvm
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: $NIGHTLY_RUN_WINDOWS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Windows
+      BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH:
+        - x86_64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-host-aarch64-linux:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_ARM_CROSS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH:
+        - arm
+        - arm64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-host-riscv64-linux:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_RISCV_CROSS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH: riscv64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-refsi-riscv-g1:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WG
+      HAL_DESCRIPTION: RV64GCVZbc_Zfh
+    strategy:
+      matrix:
+        ARCH:
+        - x86_64
+        BUILD_TYPE:
+        - Release
+        CA_HAL_NAME:
+        - refsi
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-refsi-riscv-m1:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      HAL_REFSI_SOC: M1
+      HAL_REFSI_THREAD_MODE: WG
+      MUX_COMPILERS_TO_ENABLE: refsi_m1
+    strategy:
+      matrix:
+        ARCH:
+        - x86_64
+        BUILD_TYPE:
+        - Release
+        CA_HAL_NAME:
+        - refsi
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  build-offline-linux:
+    needs: build-native
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      ARTEFACT_CHECKOUT_PATH: "${{ github.workspace }}/archive"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH:
+        - x86
+        - x86_64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run:
+        "!reference":
+        - ".pull_build_linux_release"
+        - script
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run: python -u scripts/build.py --verbose --build_type ${{ matrix.BUILD_TYPE }} --arch ${{ matrix.ARCH }} --generator Ninja --clean --define CA_CL_ENABLE_ICD_LOADER=ON --target check-ock --external_clc $ARTEFACT_CHECKOUT_PATH/bin/clc --offline_only -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON
+  build-offline-windows:
+    needs: build-windows
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ matrix.ARCH }} != "x86" && ${{ matrix.BUILD_TYPE }} !~ /Debug/ && $NIGHTLY_RUN_WINDOWS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Windows
+      ARTEFACT_CHECKOUT_PATH: "${{ github.workspace }}/archive"
+    strategy:
+      matrix:
+        BUILD_TYPE:
+        - Release
+        - ReleaseAssert
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+        ARCH:
+        - x86_64
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run:
+        "!reference":
+        - ".clone_ock_windows"
+        - script
+    - run: python -u scripts/storage.py pull artefact.ocl Windows10 ${{ matrix.ARCH }} ${{ matrix.LLVM_BRANCH }} Release --verbose --clean --path $ARTEFACT_CHECKOUT_PATH --build_id ${{ github.workflow }}
+    - run: source/cl/tools/icd-register.ps1 "$env:CI_PROJECT_DIR/oneapi-construction-kit/build/bin/CL.dll"
+    - run: python -u scripts/build.py --verbose --build_type ${{ matrix.BUILD_TYPE }} --arch ${{ matrix.ARCH }} --generator Ninja --compiler vs2019 --clean --define CA_CL_ENABLE_ICD_LOADER=ON --target check-ock --external_clc $ARTEFACT_CHECKOUT_PATH/bin/clc.exe --offline_only -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON
+  test-aubsan:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_SANITIZERS == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      CLC_BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  test-tsan:
+    needs: ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_SANITIZERS == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      CLC_BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  test-aubsan-offline:
+    needs:
+    - build-native
+    - ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_SANITIZERS == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      CLC_BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  test-tsan-offline:
+    needs:
+    - build-native
+    - ca_meta_requires_llvm
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_SANITIZERS == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      CLC_BUILD_ID: "${{ github.workflow }}"
+    strategy:
+      matrix:
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_PREVIOUS"
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  test-unitcl-host-aarch64-linux:
+    needs: build-host-aarch64-linux
+    runs-on:
+      - self-hosted
+      - arm64
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-arm64"
+    if: $NIGHTLY_RUN_ARM_CROSS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      ARTEFACT_CHECKOUT_PATH: "${{ github.workspace }}/CA"
+      ARCH: arm64
+      BUILD_TYPE: Release
+      LLVM_BRANCH: "$NIGHTLY_LLVM_PREVIOUS"
+      CA_INSTALL_DIR: "$ARTEFACT_CHECKOUT_PATH"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run:
+        "!reference":
+        - ".pull_build_linux_release"
+        - script
+    - run: cd $ARTEFACT_CHECKOUT_PATH
+    - run: OCL_ICD_FILENAMES=$PWD/lib/libCL.so OCL_ICD_VENDORS=/dev/null ./bin/UnitCL --gtest_output=xml:build/UnitCL.xml --gtest_filter=-Execution/Weak*Single*/*OpenCLC
+  test-unitcl-host-riscv64-linux:
+    needs: build-host-riscv64-linux
+    runs-on:
+      - self-hosted
+      - dev-linux
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:24.04-x86_64"
+    if: $NIGHTLY_RUN_RISCV_CROSS_HOST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu24
+      ARTEFACT_CHECKOUT_PATH: "${{ github.workspace }}/CA"
+      ARCH: riscv64
+      BUILD_TYPE: Release
+      LLVM_BRANCH: "$NIGHTLY_LLVM_PREVIOUS"
+      CA_INSTALL_DIR: "$ARTEFACT_CHECKOUT_PATH"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run:
+        "!reference":
+        - ".pull_build_linux_release"
+        - script
+    - run: cd $ARTEFACT_CHECKOUT_PATH
+    - run: OCL_ICD_FILENAMES=$PWD/lib/libCL.so OCL_ICD_VENDORS=/dev/null qemu-riscv64 -L /usr/riscv64-linux-gnu bin/UnitCL --gtest_output=xml:build/UnitCL.xml
+  test-unitcl-refsi-riscv-g1:
+    needs: build-refsi-riscv-g1
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+    strategy:
+      matrix:
+        CA_RISCV_VF:
+        - 1,S
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        name: build-refsi-riscv-g1
+  test-unitcl-refsi-riscv-m1:
+    needs: build-refsi-riscv-m1
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+    strategy:
+      matrix:
+        CA_RISCV_VF:
+        - '4'
+        - 1,S
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        name: build-refsi-riscv-m1
+  notify-zulip-fail:
+    needs:
+    - ca_trigger_llvm
+    - ca_meta_requires_llvm
+    - build-native
+    - build-windows
+    - build-host-aarch64-linux
+    - build-host-riscv64-linux
+    - build-refsi-riscv-g1
+    - build-refsi-riscv-m1
+    runs-on: ubuntu-latest
+    if: failure()
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      ZULIP_PIPELINE_NAME: nightly pipeline
+      ZULIP_STATUS_BADGE: ":red:"
+      ZULIP_STATUS: failed
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  notify-zulip-success:
+    needs:
+    - ca_trigger_llvm
+    - ca_meta_requires_llvm
+    - build-native
+    - build-windows
+    - build-host-aarch64-linux
+    - build-host-riscv64-linux
+    - build-refsi-riscv-g1
+    - build-refsi-riscv-m1
+    runs-on: ubuntu-latest
+    if: success()
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      ZULIP_PIPELINE_NAME: nightly pipeline
+      ZULIP_STATUS_BADGE: ":green:"
+      ZULIP_STATUS: passed
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+  merge-to-stable:
+    needs:
+    - build-offline-linux
+    - build-offline-windows
+    - test-aubsan
+    - test-tsan
+    - test-aubsan-offline
+    - test-tsan-offline
+    - test-unitcl-host-aarch64-linux
+    - test-unitcl-host-riscv64-linux
+    - test-unitcl-refsi-riscv-g1
+    - test-unitcl-refsi-riscv-m1
+    - notify-zulip-fail
+    - notify-zulip-success
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_OCK_BRANCH == "main" && $NIGHTLY_MERGE_TO_STABLE == "true"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '0'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+      ARTEFACT_CHECKOUT_PATH: "${{ github.workspace }}/archive"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '0'
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run: git pull --unshallow
+    - run: git remote add origin-write https://oauth2:$CA_GIT_WRITE_TOKEN@git.office.codeplay.com/ComputeAorta/oneapi-construction-kit.git
+    - run: git fetch origin-write stable
+    - run: git checkout -b stable origin-write/stable
+    - run: git merge --ff-only main
+    - run: git push origin-write stable
+  publish-docs:
+    needs: merge-to-stable
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_OCK_BRANCH == "main" && $NIGHTLY_MERGE_TO_STABLE == "true"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_LLVM_LATEST: release_170
+      NIGHTLY_LLVM_PREVIOUS: release_160
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_HAVE_NATIVE_AARCH64: 'false'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_SEND_ZULIP: '0'
+      PLATFORM: Ubuntu20
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run: python -u scripts/build.py --verbose --artefact_name "$NIGHTLY_LLVM_PREVIOUS" --generator Ninja --clean --target doc_html
+    - run: python -u scripts/storage-publish.py --doc ComputeAorta build/doc/html https://distribution.office.codeplay.com/ComputeAorta

--- a/.github/workflows/ci-github.yml
+++ b/.github/workflows/ci-github.yml
@@ -1,0 +1,7825 @@
+name: ComputeAorta/ci-github
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+  - cron: 0 19 * * TUE,THU
+  - cron: 0 18 * * 6
+  - cron: 0 8 * * 6
+  - cron: 0 19 * * 5
+  - cron: 0 20 * * MON,WED
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  STORAGE_USER: "${{ secrets.STORAGE_USER }}"
+  STORAGE_PASS: "${{ secrets.STORAGE_PASS }}"
+  ZULIP_TOKEN: "${{ secrets.ZULIP_TOKEN }}"
+  ComputeAortaCL_TOKEN: "${{ secrets.ComputeAortaCL_TOKEN }}"
+  ComputeAortaCLVK_TOKEN: "${{ secrets.ComputeAortaCLVK_TOKEN }}"
+  SCCACHE_REDIS: redis://buildcache01.office.codeplay.com
+  OLD_CA_GITLAB_API_TOKEN: "${{ secrets.OLD_CA_GITLAB_API_TOKEN }}"
+  OLD_CA_GIT_WRITE_TOKEN: "${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}"
+  CLICOLOR_FORCE: '1'
+  GTEST_COLOR: 'yes'
+  CA_GIT_WRITE_TOKEN: "${{ secrets.CA_GIT_WRITE_TOKEN }}"
+  CA_GITLAB_API_TOKEN: "${{ secrets.CA_GITLAB_API_TOKEN }}"
+  LLVM_GIT_WRITE_TOKEN: zrHPYsf6BVupQeYySmnH
+jobs:
+  mr-run-doc-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-host-ubuntu-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-host-windows-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-riscv-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-lint-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-bench-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-run-bench-skylake-:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "merge_request_event"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo ok, run jobs
+  mr-clang-tidy-changes-only:
+    needs: mr-run-lint-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    strategy:
+      matrix:
+        LLVM_VERSION:
+        - "$LLVM_PREVIOUS"
+        - "$LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: env
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name ${{ matrix.LLVM_VERSION }} -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON --target build.ninja
+    - run: ninja -C build $(ninja -C build -t targets all | sed -nE 's/(\.cpp|\.h):.*/\1/p')
+    - run: ./scripts/compute-dependants.py --exclude-filter='(/build/.*\.s$)|(source/cl/test/OpenCL-CTS)|(.*/(external|cookie)/.*)' --build-dir="${{ github.workspace }}/oneapi-construction-kit/build" `git diff --name-only --diff-filter=d origin/$MR_TARGET_BRANCH..HEAD | grep -P '\.(c|cc|cxx|cpp|h|hh|hpp|hxx)$'` | tee /dev/stderr | parallel --verbose -- clang-tidy-17 --quiet -p "${{ github.workspace }}/oneapi-construction-kit/build/" "{}"
+  mr-doc-pdf:
+    needs: mr-run-doc-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_DOC == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      TARGET: doc_pdf
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run:
+      - echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+      - git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+      - cd oneapi-construction-kit
+      - echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+      - git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+      - git config user.name "${{ github.actor }}"
+      - git config user.email "${{ github.actor }}"
+      - git fetch github-user
+      - echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+      - git merge github-user/"$OCK_BRANCH"
+      - git log -1
+      - cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py --verbose --clean --build_type Release -GNinja --artefact_name $LLVM_PREVIOUS --target $TARGET
+    - run: mkdir public
+    - run: cp build/doc/pdf/ComputeAorta*.pdf public
+    - run: cp build/doc/pdf/ComputeMux*.pdf public
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: oneapi-construction-kit/public/
+  env-info:
+    needs:
+    - mr-clang-tidy-changes-only
+    - mr-doc-pdf
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: (${{ github.event_name }} == "web" || ${{ github.event_name }} == "schedule") && $CA_PIPELINE_TYPE == "nightly"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: 'echo "Building: $LLVM_PREVIOUS / $LLVM_LATEST"'
+    - run: env
+  mr-ubuntu-gcc-x86-llvm-previous-cl3-0-release:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: Release
+      Arch: x86
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: Release
+      Arch: x86_64
+      LLVMBranch: "$LLVM_LATEST"
+      Target: check-ock
+      Images: 'ON'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-clang-x86-llvm-latest-cl3-0:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86
+      LLVMBranch: "$LLVM_LATEST"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: clang-17
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: clang-17
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --binary_dir build_offline --target check-ock --offline_only --external_clc ${{ github.workspace }}/oneapi-construction-kit/build/bin/clc -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_FP16=$FP16 -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: arm64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock-cross
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'ON'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-riscv-cl3-0:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: refsi_m1
+      HAL_DESCRIPTION: RV64GCV
+      HAL_REFSI_SOC: M1
+      HAL_REFSI_THREAD_MODE: WG
+      TARGET: install
+      DISABLE_VECZ_CHECKS: 'ON'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS -DCA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE -DCA_RISCV_ENABLED=ON -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=$DISABLE_VECZ_CHECKS -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=ON -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON -DCA_USE_LINKER=gold -DHAL_DESCRIPTION=$HAL_DESCRIPTION -DHAL_REFSI_SOC=$HAL_REFSI_SOC -DHAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE
+    - run: python -u scripts/storage.py pull artefact.ca-opencl-cts --verbose --clean --path CA-OpenCL-CTS Ubuntu20 x86_64 14 Release
+    - run: python scripts/testing/run_cities.py -s scripts/jenkins/cts_summary/opencl_conformance_tests_wimpy_very_quick.csv -b CA-OpenCL-CTS/bin -e "CA_RISCV_VF=1,S" -L build/lib -e OCL_ICD_FILENAMES=$PWD/build/lib/libCL.so -e OCL_ICD_VENDORS=/dev/null --timeout 00:10:00 --verbose -l build/cts.log -f build/cts.fail -r build/cts_riscv_1s.xml
+    - run: ninja -C build check-ock
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: |-
+          oneapi-construction-kit/build/*.fail
+          oneapi-construction-kit/build/*.log
+  mr-ubuntu-gcc-x86_64-riscv-cl3-0-part2:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: refsi_m1
+      HAL_DESCRIPTION: RV64GCV
+      HAL_REFSI_SOC: M1
+      HAL_REFSI_THREAD_MODE: WG
+      TARGET: install
+      DISABLE_VECZ_CHECKS: 'OFF'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS -DCA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE -DCA_RISCV_ENABLED=ON -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=$DISABLE_VECZ_CHECKS -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=ON -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON -DCA_USE_LINKER=gold -DHAL_DESCRIPTION=$HAL_DESCRIPTION -DHAL_REFSI_SOC=$HAL_REFSI_SOC -DHAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE
+    - run: python -u scripts/storage.py pull artefact.ca-opencl-cts --verbose --clean --path CA-OpenCL-CTS Ubuntu20 x86_64 14 Release
+    - run: python scripts/testing/run_cities.py -s scripts/jenkins/cts_summary/opencl_conformance_tests_wimpy_very_quick.csv -b CA-OpenCL-CTS/bin -e "CA_RISCV_VF=1,S,VP" -e OCL_ICD_FILENAMES=$PWD/build/lib/libCL.so -e OCL_ICD_VENDORS=/dev/null -L build/lib --timeout 00:10:00 --verbose -l build/cts.log -f build/cts.fail -r build/cts_riscv_1svp.xml
+    - run: ninja -C build check-ock-UnitCL-group-vecz
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: |-
+          oneapi-construction-kit/build/*.fail
+          oneapi-construction-kit/build/*.log
+  mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: riscv
+      HAL_DESCRIPTION: RV64GCV_Zfh
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WG
+      TARGET: check-ock
+      DISABLE_VECZ_CHECKS: 'ON'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS -DCA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE -DCA_RISCV_ENABLED=ON -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=$DISABLE_VECZ_CHECKS -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=ON -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON -DCA_USE_LINKER=gold -DHAL_DESCRIPTION=$HAL_DESCRIPTION -DHAL_REFSI_SOC=$HAL_REFSI_SOC -DHAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: riscv
+      HAL_DESCRIPTION: RV64GCV_Zfh
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WG
+      TARGET: check-ock-UnitCL-group-vecz
+      DISABLE_VECZ_CHECKS: 'OFF'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS -DCA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE -DCA_RISCV_ENABLED=ON -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=$DISABLE_VECZ_CHECKS -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=ON -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON -DCA_USE_LINKER=gold -DHAL_DESCRIPTION=$HAL_DESCRIPTION -DHAL_REFSI_SOC=$HAL_REFSI_SOC -DHAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi"
+      MUX_COMPILERS_TO_ENABLE: refsi_g1_wi
+      HAL_DESCRIPTION: RV64GCV
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WI
+      TARGET: install
+      DISABLE_VECZ_CHECKS: 'ON'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS -DCA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE -DCA_RISCV_ENABLED=ON -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=$DISABLE_VECZ_CHECKS -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=ON -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON -DCA_USE_LINKER=gold -DHAL_DESCRIPTION=$HAL_DESCRIPTION -DHAL_REFSI_SOC=$HAL_REFSI_SOC -DHAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE
+    - run: python -u scripts/storage.py pull artefact.ca-opencl-cts --verbose --clean --path CA-OpenCL-CTS Ubuntu20 x86_64 14 Release
+    - run: echo 'Subgroups,subgroups/test_subgroups barrier_functions_core' >> skipped.txt
+    - run: python scripts/testing/run_cities.py -s scripts/jenkins/cts_summary/opencl_conformance_tests_wimpy_very_quick.csv -i skipped.txt -b CA-OpenCL-CTS/bin -L build/lib -e OCL_ICD_FILENAMES=$PWD/build/lib/libCL.so -e OCL_ICD_VENDORS=/dev/null --timeout 00:10:00 --verbose -l build/cts.log -f build/cts.fail -r build/cts_refsi_g1_wi.xml
+    - run: ninja -C build check-ock
+    - run: ninja -C build check-ock-UnitCL-half
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: |-
+          oneapi-construction-kit/build/*.fail
+          oneapi-construction-kit/'build/*.log'
+  mr-ubuntu-gcc-x86_64-clik:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: cmake -Bbuild_clik -GNinja -DCMAKE_INSTALL_PREFIX=install clik
+    - run: LD_PRELOAD=/lib/x86_64-linux-gnu/libpthread.so.0 ninja -Cbuild_clik check
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-clik-refsi:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: cmake -Bbuild_clik -GNinja -DCMAKE_INSTALL_PREFIX=install -DCLIK_HAL_NAME=refsi -DHAL_REFSI_SOC=M1 -DCLIK_EXTERNAL_HAL_DIR=${{ github.workspace }}/oneapi-construction-kit/examples/refsi/hal_refsi clik
+    - run: LD_PRELOAD=/lib/x86_64-linux-gnu/libpthread.so.0 ninja -Cbuild_clik check
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-refsi-tutorial-end:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: riscv
+      TARGET: install
+      ONEAPI_CON_KIT_DIR: "${{ github.workspace }}/oneapi-construction-kit"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: pip install cookiecutter
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: scripts/setup_new_target_tutorial.sh -s end -e /refsi_tutorial -f "refsi_wrapper_pass;clmul;replace_mem" $PWD
+    - run: cd /refsi_tutorial
+    - run: python -u $ONEAPI_CON_KIT_DIR/scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET --source_dir $PWD -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="refsi_tutorial" -DCA_REFSI_TUTORIAL_ENABLED=ON -DCA_USE_LINKER=gold -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=$ONEAPI_CON_KIT_DIR -DCA_EXTERNAL_REFSI_TUTORIAL_HAL_DIR=$PWD/hal_refsi_tutorial
+    - run: ninja -Cbuild check-ock-refsi_tutorial-lit
+    - run: OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/oneAPIConstructionKit/lib/libCL.so $PWD/build/oneAPIConstructionKit/bin/UnitCL --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-cpu:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      TARGET: check-ock-UnitCL
+      ONEAPI_CON_KIT_DIR: "${{ github.workspace }}/oneapi-construction-kit"
+      LLVM_VERSION: "$LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: pip install cookiecutter
+    - run: python -u scripts/create_target.py $PWD scripts/new_target_templates/cpu_x86.json --external-dir /cpu_hal_ock
+    - run: cd /cpu_hal_ock
+    - run: $ONEAPI_CON_KIT_DIR/scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET --source_dir $PWD -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="cpu" -DCA_CPU_ENABLED=ON -DCA_USE_LINKER=gold -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=ON -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=$ONEAPI_CON_KIT_DIR -DCA_EXTERNAL_CPU_HAL_DIR=$ONEAPI_CON_KIT_DIR/clik/external/hal_cpu
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-x86_64-refsi-tutorial-start:
+    needs: mr-run-riscv-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+      LLVM_VERSION: "$LLVM_LATEST"
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: riscv
+      ONEAPI_CON_KIT_DIR: "${{ github.workspace }}/oneapi-construction-kit"
+      TARGET: install
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: pip install cookiecutter
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: scripts/setup_new_target_tutorial.sh -s start -e /refsi_tutorial $PWD
+    - run: cd /refsi_tutorial
+    - run: python -u $ONEAPI_CON_KIT_DIR/scripts/build.py -Bbuild -GNinja --verbose --clean --build_type ReleaseAssert --artefact_name $LLVM_VERSION --target $TARGET --source_dir $PWD -DCA_ENABLE_HOST_IMAGE_SUPPORT=OFF -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_MUX_TARGETS_TO_ENABLE="refsi_tutorial" -DCA_REFSI_TUTORIAL_ENABLED=ON -DCA_USE_LINKER=gold -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=$ONEAPI_CON_KIT_DIR -DCA_EXTERNAL_REFSI_TUTORIAL_HAL_DIR=$PWD/hal_refsi_tutorial
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-windows-msvc-x86_64-llvm-previous-cl3-0-images:
+    needs: mr-run-host-windows-
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'ON'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: vs2019
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: git submodule update --init --recursive
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: source/cl/tools/icd-register.ps1 "$env:CI_PROJECT_DIR/oneapi-construction-kit/build/bin/CL.dll"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-windows-msvc-x86_64-llvm-previous-cl3-0-offline:
+    needs: mr-run-host-windows-
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: vs2019
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: git submodule update --init --recursive
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: source/cl/tools/icd-register.ps1 "$env:CI_PROJECT_DIR/oneapi-construction-kit/build/bin/CL.dll"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --binary_dir build_offline --target check-ock --offline_only --external_clc "${{ github.workspace }}/oneapi-construction-kit/build/bin/clc.exe" -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-build-ock-in-tree-llvm-17-0-6:
+    needs: mr-run-host-ubuntu-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: cd ..
+    - run: git clone https://github.com/llvm/llvm-project.git -b llvmorg-17.0.6 --depth 1
+    - run: cd llvm-project
+    - run: cmake -S llvm -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM;RISCV" -DLLVM_EXTERNAL_PROJECTS=ock -DLLVM_EXTERNAL_OCK_SOURCE_DIR=$PWD/../oneapi-construction-kit
+    - run: ninja -C build check-ock-vecz-lit
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  ca_clean_node:
+    needs: env-info
+    runs-on: ubuntu-latest
+    if: $CA_PIPELINE_TYPE == "cleaner"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: CA_MOUNT_LOCATION="/media/nfs/poolfield1"
+    - run: git clone -b v2.1 git@git.office.codeplay.com:tools/artefact-manager.git
+    - run: pip3 install lxml
+    - run: python3 artefact-manager/cleanup_new.py --store-path ${CA_MOUNT_LOCATION}/artefact_store --days-to-keep 7 --keep-newest obviously_invalid_tag --earliest-date "2000-01-01 12:00:00"
+  mr-benchmark-diff:
+    needs: mr-run-bench-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event"  && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      HOST_TARGET_CPU: ''
+      RUN_PREFIX: 'default cpu: '
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run:
+      - echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+      - git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+      - cd oneapi-construction-kit
+      - echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+      - git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+      - git config user.name "${{ github.actor }}"
+      - git config user.email "${{ github.actor }}"
+      - git fetch github-user
+      - echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+      - git merge github-user/"$OCK_BRANCH"
+      - git log -1
+      - cp -r ../scripts/*.* scripts
+    - run: git checkout origin/$MR_TARGET_BRANCH
+    - run: echo building OCK at $MR_TARGET_BRANCH
+    - run: git log -1
+    - run: python -u scripts/build.py --build_type Release -GNinja --artefact_name $LLVM_PREVIOUS --target install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_USE_LINKER=gold -DCA_HOST_TARGET_CPU=$HOST_TARGET_CPU
+    - run: git clone git@git.office.codeplay.com:ComputeAorta/PerfCL
+    - run: git -C PerfCL submodule update --init --recursive
+    - run: cmake PerfCL -BPerfCL/build -GNinja -DPERFCL_OPENCL_INCLUDE=$PWD/build/install/include -DPERFCL_OPENCL_LIBRARY=$PWD/build/install/lib -DPERFCL_ITERATIONS=10
+    - run: OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/install/lib/libCL.so PERFCL_RUN_UID="${RUN_PREFIX}${MR_TARGET_BRANCH} ($(git rev-parse --short HEAD))" ninja -C PerfCL/build bench
+    - run: git checkout -
+    - run: echo building OCK at $OCK_BRANCH
+    - run: git log -1
+    - run: ninja -C build install
+    - run: OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/install/lib/libCL.so PERFCL_RUN_UID="${RUN_PREFIX}${OCK_BRANCH} ($(git rev-parse --short HEAD))" ninja -C PerfCL/build plot
+    - run: mv PerfCL/build/html public
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: oneapi-construction-kit/public/
+  mr-benchmark-diff-skylake:
+    needs: mr-run-bench-skylake-
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event"  && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 3600
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      HOST_TARGET_CPU: skylake
+      RUN_PREFIX: 'skylake: '
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run:
+      - echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+      - git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+      - cd oneapi-construction-kit
+      - echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+      - git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+      - git config user.name "${{ github.actor }}"
+      - git config user.email "${{ github.actor }}"
+      - git fetch github-user
+      - echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+      - git merge github-user/"$OCK_BRANCH"
+      - git log -1
+      - cp -r ../scripts/*.* scripts
+    - run: git checkout origin/$MR_TARGET_BRANCH
+    - run: echo building OCK at $MR_TARGET_BRANCH
+    - run: git log -1
+    - run: python -u scripts/build.py --build_type Release -GNinja --artefact_name $LLVM_PREVIOUS --target install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_USE_LINKER=gold -DCA_HOST_TARGET_CPU=$HOST_TARGET_CPU
+    - run: git clone git@git.office.codeplay.com:ComputeAorta/PerfCL
+    - run: git -C PerfCL submodule update --init --recursive
+    - run: cmake PerfCL -BPerfCL/build -GNinja -DPERFCL_OPENCL_INCLUDE=$PWD/build/install/include -DPERFCL_OPENCL_LIBRARY=$PWD/build/install/lib -DPERFCL_ITERATIONS=10
+    - run: OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/install/lib/libCL.so PERFCL_RUN_UID="${RUN_PREFIX}${MR_TARGET_BRANCH} ($(git rev-parse --short HEAD))" ninja -C PerfCL/build bench
+    - run: git checkout -
+    - run: echo building OCK at $OCK_BRANCH
+    - run: git log -1
+    - run: ninja -C build install
+    - run: OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/install/lib/libCL.so PERFCL_RUN_UID="${RUN_PREFIX}${OCK_BRANCH} ($(git rev-parse --short HEAD))" ninja -C PerfCL/build plot
+    - run: mv PerfCL/build/html public
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: oneapi-construction-kit/public/
+  ca-nightly-pipeline:
+    name: ".gitlab-ci-nightly_pipeline"
+    needs:
+    - mr-ubuntu-gcc-x86-llvm-previous-cl3-0-release
+    - mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release
+    - mr-ubuntu-clang-x86-llvm-latest-cl3-0
+    - mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline
+    - mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16
+    - mr-ubuntu-gcc-x86_64-riscv-cl3-0
+    - mr-ubuntu-gcc-x86_64-riscv-cl3-0-part2
+    - mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0
+    - mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz
+    - mr-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0
+    - mr-ubuntu-gcc-x86_64-clik
+    - mr-ubuntu-gcc-x86_64-clik-refsi
+    - mr-ubuntu-gcc-x86_64-refsi-tutorial-end
+    - mr-ubuntu-gcc-x86_64-cpu
+    - mr-ubuntu-gcc-x86_64-refsi-tutorial-start
+    - mr-windows-msvc-x86_64-llvm-previous-cl3-0-images
+    - mr-windows-msvc-x86_64-llvm-previous-cl3-0-offline
+    - mr-ubuntu-build-ock-in-tree-llvm-17-0-6
+    - ca_clean_node
+    uses: "./.github/workflows/.gitlab-ci-nightly_pipeline.yml"
+  stable-ubuntu20-x86_64-llvm-previous:
+    needs:
+    - mr-benchmark-diff
+    - mr-benchmark-diff-skylake
+    - ca-nightly-pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "push" && ${{ github.ref }} == "stable" || ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "stable"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_PIPELINE_NAME: test job
+      ZULIP_STATUS_BADGE: ":red:"
+      ZULIP_STREAM: oneAPI Construction Kit
+      ZULIP_TOPIC: GitLab CI
+      DISTRIB_ID: '20.04'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: git checkout stable
+    - run: git clone git@git.office.codeplay.com:ComputeAorta/ci-github.git
+    - run: cp -r ci-github/scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type Release --arch x86_64 --artefact_name "$LLVM_PREVIOUS" -DCA_CL_ENABLE_ICD_LOADER=ON -DOCL_EXTENSION_cl_khr_command_buffer=ON -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON
+    - run: python -u scripts/publish-nightly.py build/install ComputeAorta-ubuntu${DISTRIB_ID}-x86_64-llvm-${LLVM_PREVIOUS}
+    - run: if [ "${{ job.status }}" != "failed" ]; then exit 0; fi
+      if: always()
+    - run: curl -X POST https://chat.codeplay.com/api/v1/messages -u "computeaorta-gitlab-bot@chat.codeplay.com:$ZULIP_TOKEN" --data-urlencode "type=stream" --data-urlencode "to=$ZULIP_STREAM" --data-urlencode "subject=$ZULIP_TOPIC" --data-urlencode "content=$ZULIP_STATUS_BADGE The job ${{ github.job }} in the [$ZULIP_PIPELINE_NAME](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) pipeline for ${{ github.event.repository.full_name }} finished with status failed."
+      if: always()
+  stable-ubuntu20-riscv-refsi:
+    needs:
+    - mr-benchmark-diff
+    - mr-benchmark-diff-skylake
+    - ca-nightly-pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "push" && ${{ github.ref }} == "stable" || ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "stable"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_PIPELINE_NAME: test job
+      ZULIP_STATUS_BADGE: ":red:"
+      ZULIP_STREAM: oneAPI Construction Kit
+      ZULIP_TOPIC: GitLab CI
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: git checkout stable
+    - run: git clone git@git.office.codeplay.com:ComputeAorta/ci-github.git
+    - run: cp -r ci-github/scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type Release --artefact_name "$LLVM_LATEST" --target install -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_EXTERNAL_MUX_COMPILER_DIRS=${{ github.workspace }}/examples/refsi/refsi_m1/compiler/refsi_m1 -DCA_MUX_COMPILERS_TO_ENABLE="refsi_m1" -DHAL_REFSI_SOC="M1" -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_REFSI_M1_DEMO_MODE=ON -DOCL_EXTENSION_cl_codeplay_soft_math=OFF -DOCL_EXTENSION_cl_codeplay_program_snapshot=OFF
+    - run: python -u scripts/publish-nightly.py build/install ComputeAorta-ubuntu20.04-riscv-refsi
+    - run: if [ "${{ job.status }}" != "failed" ]; then exit 0; fi
+      if: always()
+    - run: curl -X POST https://chat.codeplay.com/api/v1/messages -u "computeaorta-gitlab-bot@chat.codeplay.com:$ZULIP_TOKEN" --data-urlencode "type=stream" --data-urlencode "to=$ZULIP_STREAM" --data-urlencode "subject=$ZULIP_TOPIC" --data-urlencode "content=$ZULIP_STATUS_BADGE The job ${{ github.job }} in the [$ZULIP_PIPELINE_NAME](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) pipeline for ${{ github.event.repository.full_name }} finished with status failed."
+      if: always()
+  stable-ubuntu20-cl3-0-riscv-llvm-latest-riscv-refsi:
+    needs:
+    - mr-benchmark-diff
+    - mr-benchmark-diff-skylake
+    - ca-nightly-pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "push" && ${{ github.ref }} == "stable" || ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "stable"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_PIPELINE_NAME: test job
+      ZULIP_STATUS_BADGE: ":red:"
+      ZULIP_STREAM: oneAPI Construction Kit
+      ZULIP_TOPIC: GitLab CI
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: git checkout stable
+    - run: git clone git@git.office.codeplay.com:ComputeAorta/ci-github.git
+    - run: cp -r ci-github/scripts/*.* scripts
+    - run: python -u scripts/build.py -Bbuild -GNinja --verbose --clean --build_type Release --artefact_name "$LLVM_LATEST" --target install -DCA_ENABLE_API=cl -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_EXTERNAL_MUX_COMPILER_DIRS=${{ github.workspace }}/examples/refsi/refsi_m1/compiler/refsi_m1 -DCA_MUX_COMPILERS_TO_ENABLE="refsi_m1" -DHAL_REFSI_SOC="M1" -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_REFSI_M1_DEMO_MODE=ON -DOCL_EXTENSION_cl_codeplay_soft_math=OFF -DOCL_EXTENSION_cl_codeplay_program_snapshot=OFF
+    - run: python -u scripts/publish-nightly.py build/install ComputeAorta-ubuntu20.04-cl3.0-riscv-llvm-latest+riscv-refsi
+    - run: if [ "${{ job.status }}" != "failed" ]; then exit 0; fi
+      if: always()
+    - run: curl -X POST https://chat.codeplay.com/api/v1/messages -u "computeaorta-gitlab-bot@chat.codeplay.com:$ZULIP_TOKEN" --data-urlencode "type=stream" --data-urlencode "to=$ZULIP_STREAM" --data-urlencode "subject=$ZULIP_TOPIC" --data-urlencode "content=$ZULIP_STATUS_BADGE The job ${{ github.job }} in the [$ZULIP_PIPELINE_NAME](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) pipeline for ${{ github.event.repository.full_name }} finished with status failed."
+      if: always()
+  validate-release:
+    needs:
+    - stable-ubuntu20-x86_64-llvm-previous
+    - stable-ubuntu20-riscv-refsi
+    - stable-ubuntu20-cl3-0-riscv-llvm-latest-riscv-refsi
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "release"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: rm -r -f oneapi-construction-kit
+    - run: echo cloning oneapi-construction-kit from branch "v${CA_RELEASE_VERSION}"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b "v${CA_RELEASE_VERSION}" --depth 1
+    - run: cp -r scripts/*.* oneapi-construction-kit/scripts
+    - run: cd oneapi-construction-kit
+    - run: git log -1
+    - run: cp scripts/release.py release.py
+    - run: python -u release.py check $CA_RELEASE_VERSION
+    - run: mkdir -p /media/nfs/poolfield2/releases/$CA_RELEASE_VERSION
+  release-binary-ubuntu:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "release"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      PLATFORM: Ubuntu20
+    strategy:
+      matrix:
+        ARCH:
+        - x86
+        - x86_64
+        - arm
+        - arm64
+        LLVM_VERSION:
+        - "$LLVM_PREVIOUS"
+        - "$LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: rm -r -f oneapi-construction-kit
+    - run: echo cloning oneapi-construction-kit from branch "v${CA_RELEASE_VERSION}"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b "v${CA_RELEASE_VERSION}" --depth 1
+    - run: cp -r scripts/*.* oneapi-construction-kit/scripts
+    - run: cd oneapi-construction-kit
+    - run: git log -1
+    - run: python -u scripts/build.py -GNinja --clean --verbose --build_type Release --arch ${{ matrix.ARCH }} --artefact_name ${LLVM_VERSION} --target install
+    - run: mkdir -p public
+    - run: tar -zcvf public/CA-${CA_RELEASE_VERSION}-${PLATFORM}-${ARCH}-llvm-${LLVM_VERSION}.tar.gz build/install
+    - run: python -u scripts/storage-publish.py --binary $CA_RELEASE_VERSION public https://distribution.office.codeplay.com/computeaorta
+  release-binary-windows:
+    needs: validate-release
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "release"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      PLATFORM: Windows10
+    strategy:
+      matrix:
+        ARCH:
+        - x86_64
+        LLVM_VERSION:
+        - "$LLVM_PREVIOUS"
+        - "$LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: if (Test-Path oneapi-construction-kit) { rm -r -fo oneapi-construction-kit }
+    - run: echo cloning oneapi-construction-kit from branch "v${CA_RELEASE_VERSION}"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b "v${CA_RELEASE_VERSION}" --depth 1
+    - run: cp -r scripts/*.* oneapi-construction-kit/scripts
+    - run: cd oneapi-construction-kit
+    - run: git log -1
+    - run: python -u scripts/build.py -GNinja --clean --verbose --build_type Release --arch ${{ matrix.ARCH }} --artefact_name ${LLVM_VERSION} --target install
+    - run: mkdir -p public
+    - run: tar -zcvf public/CA-${CA_RELEASE_VERSION}-${PLATFORM}-${ARCH}-llvm-${LLVM_VERSION}.tar.gz build/install
+    - run: python -u scripts/storage-publish.py --binary $CA_RELEASE_VERSION public https://distribution.office.codeplay.com/computeaorta
+  trigger-announcement:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "release"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_STREAM: oneAPI Construction Kit
+      ZULIP_TOPIC: CA ${CA_RELEASE_VERSION}
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: python -u scripts/release.py announce ${CA_RELEASE_VERSION} computeaorta-gitlab-bot@chat.codeplay.com ${ZULIP_TOKEN} "${ZULIP_STREAM}" "${ZULIP_TOPIC}"
+  stable-notify-success:
+    needs:
+    - stable-ubuntu20-x86_64-llvm-previous
+    - stable-ubuntu20-riscv-refsi
+    - stable-ubuntu20-cl3-0-riscv-llvm-latest-riscv-refsi
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "push" && ${{ github.ref }} == "stable" || ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "stable"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_PIPELINE_NAME: stable
+      ZULIP_STATUS_BADGE: ":green:"
+      ZULIP_STATUS: passed
+      ZULIP_STREAM: Orion
+      ZULIP_TOPIC: GitLab CI
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: PIPELINE_TOOK=$( printf '"%s"' $CI_PIPELINE_CREATED_AT | jq -r 'now - (sub("\\.\\d+Z$"; "Z") | fromdate) | gmtime | .[2:6] | map(floor) | @text "\(.[0] -1) days \(.[1]) hours \(.[2]) mins"' )
+    - run: curl -X POST https://chat.codeplay.com/api/v1/messages -u "computeaorta-gitlab-bot@chat.codeplay.com:$ZULIP_TOKEN" --data-urlencode type=stream --data-urlencode to="$ZULIP_STREAM" --data-urlencode subject="$ZULIP_TOPIC" --data-urlencode "content=$ZULIP_STATUS_BADGE The [$ZULIP_PIPELINE_NAME](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) pipeline for ${{ github.event.repository.full_name }} ($NIGHTLY_LLVM_PREVIOUS/$NIGHTLY_LLVM_LATEST) finished with status $ZULIP_STATUS (took $PIPELINE_TOOK)."
+  promote-riscv-llvm-latest-riscv-refsi:
+    needs: stable-ubuntu20-riscv-refsi
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "push" && ${{ github.ref }} == "stable" || ${{ github.event_name }} == "web" && $CA_PIPELINE_TYPE == "stable"
+    timeout-minutes: 3600
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      MERGE_TO_STABLE:
+        value: 'false'
+        description: Update the `stable` tag on the Gitlab repo
+      CA_PIPELINE_TYPE:
+        value: nightly
+        options:
+        - release
+        - stable
+        - nightly
+        - cleaner
+        description: Pipeline type
+      CA_LLVM_BRANCH:
+        value: develop
+        description: Branch to use for ca-llvm (not LLVM itself); used when running the sanitizers
+      CA_CTS_TYPE_X86:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type x86/x86_64
+      CA_CTS_TYPE_ARM:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type arm/AArch64
+      CA_CTS_TYPE_RISCV:
+        value: wimpy
+        options:
+        - none
+        - wimpy
+        - full
+        description: OpenCL CTS type RISC-V
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      RUN_SYCL_LLVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run DPC++ LLVM SYCL test suite; requires RUN_LINUX_RISCV
+      RUN_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run SYCL CTS test suite; implies building DPC++ and requires either RUN_LINUX_HOST and/or RUN_LINUX_RISCV
+      RUN_WINDOWS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Windows builds/tests
+      RUN_ARM_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run ARM cross compile builds/tests
+      RUN_RISCV_CROSS_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run RISC-V cross compile builds
+      RUN_LINUX_HOST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86/x86_64 non-riscv builds/tests
+      RUN_LINUX_RISCV:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run Linux x86_64 riscv refsi simulator builds/tests
+      RUN_WEIRD_PIPELINE:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the 'weird' tests (which check various build configurations)
+      RUN_SANITIZERS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the address and thread sanitizer checks
+      RUN_TIDY:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run the clang tidy checks (offline requires RUN_LINUX_HOST)
+      RUN_BUILD_LLVM:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Trigger a build of ca-llvm to build LLVM artifacts as part of this build. Only `LLVM_LATEST` will be built
+      BUILD_LLVM_BRANCHNAME:
+        value: main
+        description: Branchname to build for LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      BUILD_LLVM_CALLVM_BRANCH:
+        value: develop
+        description: Branchname of ca-llvm to use for building LLVM, ignored unless `RUN_BUILD_LLVM` is set
+      SEND_ZULIP:
+        value: '0'
+        options:
+        - '0'
+        - '1'
+        description: Send a job success/failure notification to Zulip.
+      BUILD_DPCPP_BRANCH:
+        value: sycl
+        description: Branch to build for DPC++
+      RUN_NATIVE_CPU_SYCL_CTS:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running native cpu sycl cts
+      RUN_REMOTE_HAL:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running remote hal
+      RUN_TORNADOVM:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Enable running tornadovm
+      ZULIP_PIPELINE_NAME: stable
+      INTEGRATION_PROJECT_ID: webservices%2Facoran-for-risc-v-documentation
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+    - run: curl -X POST -F token=$INTEGRATION_TRIGGER_TOKEN -F ref=stable ${{ github.api_url }}/projects/${INTEGRATION_PROJECT_ID}/trigger/pipeline


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://10.54.10.74/ComputeAorta/ci-github) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ComputeAorta/ci-github
- [ ] Ensure secret is available: `${{ secrets.STORAGE_USER }}`
- [ ] Ensure secret is available: `${{ secrets.STORAGE_PASS }}`
- [ ] Ensure secret is available: `${{ secrets.ZULIP_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCL_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCLVK_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GITLAB_API_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GITLAB_API_TOKEN }}`

### .gitlab-ci-nightly_pipeline
- [ ] Ensure environment variable is updated: `WORKFLOW_FILE`
- [ ] Ensure: the `workflow_dispatch` trigger is added to the $WORKFLOW_FILE workflow.
- [ ] Ensure a runner with the following labels exists: arm64
- [ ] Ensure a runner with the following labels exists: dev-linux