### PR TITLE
Convert ComputeAorta/ci-github-mrexport to GitHub Actions

### DIFF
--- a/.github/workflows/ci-github-mrexport.yml
+++ b/.github/workflows/ci-github-mrexport.yml
@@ -1,0 +1,282 @@
+name: ComputeAorta/ci-github-mrexport
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  STORAGE_USER: "${{ secrets.STORAGE_USER }}"
+  STORAGE_PASS: "${{ secrets.STORAGE_PASS }}"
+  ZULIP_TOKEN: "${{ secrets.ZULIP_TOKEN }}"
+  ComputeAortaCL_TOKEN: "${{ secrets.ComputeAortaCL_TOKEN }}"
+  ComputeAortaCLVK_TOKEN: "${{ secrets.ComputeAortaCLVK_TOKEN }}"
+  SCCACHE_REDIS: redis://buildcache01.office.codeplay.com
+  OLD_CA_GITLAB_API_TOKEN: "${{ secrets.OLD_CA_GITLAB_API_TOKEN }}"
+  OLD_CA_GIT_WRITE_TOKEN: "${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}"
+  CLICOLOR_FORCE: '1'
+  GTEST_COLOR: 'yes'
+  CA_GIT_WRITE_TOKEN: "${{ secrets.CA_GIT_WRITE_TOKEN }}"
+  CA_GITLAB_API_TOKEN: "${{ secrets.CA_GITLAB_API_TOKEN }}"
+  LLVM_GIT_WRITE_TOKEN: zrHPYsf6BVupQeYySmnH
+jobs:
+  mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline:
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 60
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      BuildType: ReleaseAssert
+      Arch: x86
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: clang-17
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --binary_dir build_offline --target check-ock --offline_only --external_clc ${{ github.workspace }}/oneapi-construction-kit/build/bin/clc -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_FP16=$FP16 -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16:
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 60
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      BuildType: ReleaseAssert
+      Arch: arm64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock-cross
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'ON'
+      Compiler: gcc-9
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images -DCA_HOST_ENABLE_BUILTIN_KERNEL=ON -DCA_HOST_ENABLE_BUILTINS_EXTENSION=ON -DCA_HOST_ENABLE_FP16=$FP16 -DCA_ASSEMBLE_SPIRV_LL_LIT_TESTS_OFFLINE=OFF -DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM -DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer -DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer -DCA_USE_LINKER=gold
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-windows-msvc-x86_64-llvm-previous-cl3-0-images:
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 60
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'ON'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: vs2019
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: git submodule update --init --recursive
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: source/cl/tools/icd-register.ps1 "$env:CI_PROJECT_DIR/oneapi-construction-kit/build/bin/CL.dll"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+  mr-windows-msvc-x86_64-llvm-previous-cl3-0-offline:
+    runs-on: windows-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/windows:10-x86_64"
+    if: ${{ github.event_name }} == "merge_request_event" && $RUN_BUILD_TEST == "1"
+    timeout-minutes: 60
+    continue-on-error: true
+    env:
+      GIT_STRATEGY: clone
+      OCK_BRANCH:
+        value: main
+        description: Branch of OCK to build
+      GITHUB_USER:
+        value: codeplaysoftware
+        description: Github user account for checkout
+      LLVM_LATEST:
+        value: release_180
+        description: Primary sharedstorage name of LLVM artefact to use
+      LLVM_PREVIOUS:
+        value: release_170
+        description: Secondary sharedstorage name of LLVM artefact to use (set to the same as LLVM_LATEST to only build one version)
+      RUN_DOC:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run docs
+      RUN_BUILD_TEST:
+        value: '1'
+        options:
+        - '0'
+        - '1'
+        description: Run all build and test related tests including clang-tidy
+      MR_TARGET_BRANCH:
+        value: main
+        description: Target branch for merging and testing
+      BuildType: ReleaseAssert
+      Arch: x86_64
+      LLVMBranch: "$LLVM_PREVIOUS"
+      Target: check-ock
+      Images: 'OFF'
+      CommandBuffer: 'ON'
+      USM: 'ON'
+      FP16: 'OFF'
+      Compiler: vs2019
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: git submodule update --init --recursive
+    - run: echo cloning "https://github.com/codeplaysoftware/oneapi-construction-kit.git"
+    - run: git clone https://github.com/codeplaysoftware/oneapi-construction-kit.git -b $MR_TARGET_BRANCH
+    - run: cd oneapi-construction-kit
+    - run: echo adding "https://github.com/$GITHUB_USER/oneapi-construction-kit.git" as a remote
+    - run: git remote add github-user https://github.com/$GITHUB_USER/oneapi-construction-kit.git
+    - run: git config user.name "${{ github.actor }}"
+    - run: git config user.email "${{ github.actor }}"
+    - run: git fetch github-user
+    - run: echo merging $OCK_BRANCH into $MR_TARGET_BRANCH
+    - run: git merge github-user/"$OCK_BRANCH"
+    - run: git log -1
+    - run: cp -r ../scripts/*.* scripts
+    - run: source/cl/tools/icd-register.ps1 "$env:CI_PROJECT_DIR/oneapi-construction-kit/build/bin/CL.dll"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --artefact_name $LLVMBranch --target $Target -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_intel_unified_shared_memory=$USM" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+    - run: python -u scripts/build.py -GNinja --verbose --clean --build_type $BuildType --arch $Arch --compiler $Compiler --binary_dir build_offline --target check-ock --offline_only --external_clc "${{ github.workspace }}/oneapi-construction-kit/build/bin/clc.exe" -DCA_CL_ENABLE_ICD_LOADER=ON "-DCA_ENABLE_HOST_IMAGE_SUPPORT=$Images" "-DOCL_EXTENSION_cl_khr_command_buffer=$CommandBuffer" "-DOCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=$CommandBuffer"
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://10.54.10.74/ComputeAorta/ci-github-mrexport) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ComputeAorta/ci-github-mrexport
- [ ] Ensure secret is available: `${{ secrets.STORAGE_USER }}`
- [ ] Ensure secret is available: `${{ secrets.STORAGE_PASS }}`
- [ ] Ensure secret is available: `${{ secrets.ZULIP_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCL_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCLVK_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GITLAB_API_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GITLAB_API_TOKEN }}`