### PR TITLE
Convert ComputeAorta/ci-github-nightlyexport to GitHub Actions

### DIFF
--- a/.github/workflows/ci-github-nightlyexport.yml
+++ b/.github/workflows/ci-github-nightlyexport.yml
@@ -1,0 +1,207 @@
+name: ComputeAorta/ci-github-nightlyexport
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  STORAGE_USER: "${{ secrets.STORAGE_USER }}"
+  STORAGE_PASS: "${{ secrets.STORAGE_PASS }}"
+  ZULIP_TOKEN: "${{ secrets.ZULIP_TOKEN }}"
+  ComputeAortaCL_TOKEN: "${{ secrets.ComputeAortaCL_TOKEN }}"
+  ComputeAortaCLVK_TOKEN: "${{ secrets.ComputeAortaCLVK_TOKEN }}"
+  SCCACHE_REDIS: redis://buildcache01.office.codeplay.com
+  OLD_CA_GITLAB_API_TOKEN: "${{ secrets.OLD_CA_GITLAB_API_TOKEN }}"
+  OLD_CA_GIT_WRITE_TOKEN: "${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}"
+  CLICOLOR_FORCE: '1'
+  GTEST_COLOR: 'yes'
+  CA_GIT_WRITE_TOKEN: "${{ secrets.CA_GIT_WRITE_TOKEN }}"
+  CA_GITLAB_API_TOKEN: "${{ secrets.CA_GITLAB_API_TOKEN }}"
+  LLVM_GIT_WRITE_TOKEN: zrHPYsf6BVupQeYySmnH
+jobs:
+  env-info:
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    timeout-minutes: 60
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_LLVM_LATEST: release_180
+      NIGHTLY_LLVM_PREVIOUS: release_170
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_PIPELINE_TYPE: nightly
+      NIGHTLY_CA_LLVM_BRANCH: develop
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_RUN_DOC: '1'
+      NIGHTLY_RUN_BUILD_TEST: '1'
+      NIGHTLY_MR_TARGET_BRANCH: main
+      NIGHTLY_RUN_SYCL_LLVM: '1'
+      NIGHTLY_RUN_SYCL_CTS: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_RISCV_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_SEND_ZULIP: '0'
+      NIGHTLY_BUILD_DPCPP_BRANCH: sycl
+      NIGHTLY_RUN_NATIVE_CPU_SYCL_CTS: '1'
+      NIGHTLY_RUN_REMOTE_HAL: '1'
+      NIGHTLY_RUN_TORNADOVM: '1'
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+        lfs: true
+    - run: 'echo "Building: $NIGHTLY_LLVM_PREVIOUS / $NIGHTLY_LLVM_LATEST"'
+    - run: env
+  build-refsi-riscv-g1:
+    needs: env-info
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 60
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_LLVM_LATEST: release_180
+      NIGHTLY_LLVM_PREVIOUS: release_170
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_PIPELINE_TYPE: nightly
+      NIGHTLY_CA_LLVM_BRANCH: develop
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_RUN_DOC: '1'
+      NIGHTLY_RUN_BUILD_TEST: '1'
+      NIGHTLY_MR_TARGET_BRANCH: main
+      NIGHTLY_RUN_SYCL_LLVM: '1'
+      NIGHTLY_RUN_SYCL_CTS: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_RISCV_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_SEND_ZULIP: '0'
+      NIGHTLY_BUILD_DPCPP_BRANCH: sycl
+      NIGHTLY_RUN_NATIVE_CPU_SYCL_CTS: '1'
+      NIGHTLY_RUN_REMOTE_HAL: '1'
+      NIGHTLY_RUN_TORNADOVM: '1'
+      PLATFORM: Ubuntu20
+      BUILD_ID: "${{ github.workflow }}"
+      HAL_DESCRIPTION: RV64GCVZbc_Zfh
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WG
+      EXTERNAL_MUX_COMPILER_DIRS: "${{ github.workspace }}/oneapi-construction-kit/examples/refsi/refsi_m1/compiler/refsi_m1"
+      MUX_COMPILERS_TO_ENABLE: riscv
+    strategy:
+      matrix:
+        ARCH:
+        - x86_64
+        BUILD_TYPE:
+        - Release
+        CA_HAL_NAME:
+        - refsi
+        LLVM_BRANCH:
+        - "$NIGHTLY_LLVM_LATEST"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+        lfs: true
+    - run:
+        "!reference":
+        - ".clone_ock"
+        - script
+    - run: echo "Building refsi OCK ($HAL_REFSI_SOC) with build type ${{ matrix.BUILD_TYPE }} on llvm branch ${{ matrix.LLVM_BRANCH }}"
+    - run: python scripts/build.py --verbose --build_type ${{ matrix.BUILD_TYPE }} --arch ${{ matrix.ARCH }} --artefact_name ${{ matrix.LLVM_BRANCH }} --generator Ninja --clean --define CA_CL_ENABLE_ICD_LOADER=ON --define OCL_EXTENSION_cl_khr_command_buffer=ON --define OCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch=ON --define OCL_EXTENSION_cl_khr_extended_async_copies=ON --define CA_RISCV_ENABLED=ON --define CA_HAL_NAME=${{ matrix.CA_HAL_NAME }} --define CA_HAL_LOCK_DEVICE_NAME=FALSE --define CA_MUX_TARGETS_TO_ENABLE="riscv" --define CA_EXTERNAL_MUX_COMPILER_DIRS=$EXTERNAL_MUX_COMPILER_DIRS --define CA_MUX_COMPILERS_TO_ENABLE=$MUX_COMPILERS_TO_ENABLE --define HAL_DESCRIPTION=$HAL_DESCRIPTION --define HAL_REFSI_SOC=$HAL_REFSI_SOC --define HAL_REFSI_THREAD_MODE=$HAL_REFSI_THREAD_MODE --define CA_ENABLE_API=cl -B build
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        retention-days: 3
+        path: |-
+          oneapi-construction-kit/build/install/lib
+          oneapi-construction-kit/build/install/bin/UnitCL
+          oneapi-construction-kit/build/install/bin/run_cities.py
+          oneapi-construction-kit/build/install/bin/city_runner
+          oneapi-construction-kit/build/install/share
+  test-unitcl-refsi-riscv-g1:
+    needs: build-refsi-riscv-g1
+    runs-on: ubuntu-latest
+    container:
+      image: "$CI_REGISTRY/computeaorta/ci/ubuntu:20.04-x86_64"
+    if: $NIGHTLY_RUN_LINUX_RISCV == "1"
+    timeout-minutes: 60
+    env:
+      GIT_STRATEGY: clone
+      GIT_DEPTH: '3'
+      NIGHTLY_OCK_BRANCH: main
+      NIGHTLY_GITHUB_USER: codeplaysoftware
+      NIGHTLY_LLVM_LATEST: release_180
+      NIGHTLY_LLVM_PREVIOUS: release_170
+      NIGHTLY_MERGE_TO_STABLE: 'false'
+      NIGHTLY_CA_PIPELINE_TYPE: nightly
+      NIGHTLY_CA_LLVM_BRANCH: develop
+      NIGHTLY_CA_CTS_TYPE_X86: wimpy
+      NIGHTLY_CA_CTS_TYPE_ARM: wimpy
+      NIGHTLY_CA_CTS_TYPE_RISCV: wimpy
+      NIGHTLY_RUN_DOC: '1'
+      NIGHTLY_RUN_BUILD_TEST: '1'
+      NIGHTLY_MR_TARGET_BRANCH: main
+      NIGHTLY_RUN_SYCL_LLVM: '1'
+      NIGHTLY_RUN_SYCL_CTS: '1'
+      NIGHTLY_RUN_WINDOWS_HOST: '1'
+      NIGHTLY_RUN_ARM_CROSS_HOST: '1'
+      NIGHTLY_RUN_RISCV_CROSS_HOST: '1'
+      NIGHTLY_RUN_LINUX_HOST: '1'
+      NIGHTLY_RUN_LINUX_RISCV: '1'
+      NIGHTLY_RUN_WEIRD_PIPELINE: '1'
+      NIGHTLY_RUN_SANITIZERS: '1'
+      NIGHTLY_RUN_TIDY: '1'
+      NIGHTLY_RUN_BUILD_LLVM: '0'
+      NIGHTLY_BUILD_LLVM_BRANCHNAME: main
+      NIGHTLY_BUILD_LLVM_CALLVM_BRANCH: develop
+      NIGHTLY_SEND_ZULIP: '0'
+      NIGHTLY_BUILD_DPCPP_BRANCH: sycl
+      NIGHTLY_RUN_NATIVE_CPU_SYCL_CTS: '1'
+      NIGHTLY_RUN_REMOTE_HAL: '1'
+      NIGHTLY_RUN_TORNADOVM: '1'
+      PLATFORM: Ubuntu20
+      CA_INSTALL_DIR: "${{ github.workspace }}/oneapi-construction-kit/build/install"
+    strategy:
+      matrix:
+        CA_RISCV_VF:
+        - 1,S
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: '3'
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        name: build-refsi-riscv-g1
+    - run: cd $CA_INSTALL_DIR
+    - run: OCL_ICD_FILENAMES=$PWD/lib/libCL.so OCL_ICD_VENDORS=/dev/null ./bin/UnitCL --gtest_output=xml:build/UnitCL.xml
+#     # 'artifacts.junit' was not transformed because there is no suitable equivalent in GitHub Actions


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://10.54.10.74/ComputeAorta/ci-github-nightlyexport) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ComputeAorta/ci-github-nightlyexport
- [ ] Ensure secret is available: `${{ secrets.STORAGE_USER }}`
- [ ] Ensure secret is available: `${{ secrets.STORAGE_PASS }}`
- [ ] Ensure secret is available: `${{ secrets.ZULIP_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCL_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.ComputeAortaCLVK_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GITLAB_API_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.OLD_CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GIT_WRITE_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CA_GITLAB_API_TOKEN }}`